### PR TITLE
Add packageManager and node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "gdg-on-campus-hackathon-website",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.3",
+  "engines": {
+    "node": ">=20.17.0"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
This pull request includes an update to the `package.json` file to specify the package manager and Node.js version requirements for Corepack users.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5-R8): Added `"packageManager": "pnpm@9.15.3"` and an `"engines"` field to specify that Node.js version must be `>=20.17.0`.