### PR TITLE
fix: simplify event award description in HomeInformation component

### DIFF
--- a/app/HomeInformation/HomeInformation.tsx
+++ b/app/HomeInformation/HomeInformation.tsx
@@ -78,7 +78,7 @@ export default function HomeInformation() {
       {/* event awards */}
       <H2>競賽獎項</H2>
       <EventAward
-        description="優勝：各主題擇一隊伍，優勝獎金 10,000 元、獎狀、企業實體獎品，並另訂時間至 Google 臺北 101 辦公室與 Google 開發者生態團對大中華區負責人交流"
+        description="優勝：各主題擇一隊伍，優勝獎金 10,000 元、獎狀、企業實體獎品"
         prize="gold"
       />
       <EventAward


### PR DESCRIPTION
This pull request makes a minor update to the event awards information in the `HomeInformation` component. The change removes the mention of a follow-up meeting at the Google Taipei 101 office from the description of the top prize.

* Updated the `description` prop in the `EventAward` component to remove the sentence about a meeting with Google representatives at the Taipei 101 office.