### PR TITLE
fix(Carousel): resolve text selection and blank slide issues

### DIFF
--- a/app/HomeEventHighlights/HomeEventHighlights.tsx
+++ b/app/HomeEventHighlights/HomeEventHighlights.tsx
@@ -13,7 +13,7 @@ import { images, type ImageItem } from "./data/Images";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import CarouselNavButton from "../components/CarouselNavButton";
 
 export default function HomeEventHighlights() {
   const [selectedImage, setSelectedImage] = useState<ImageItem | null>(null);
@@ -104,22 +104,18 @@ export default function HomeEventHighlights() {
           ))}
         </Swiper>
 
-        <button
-          type="button"
-          aria-label="上一張花絮"
-          onMouseDown={(e) => e.preventDefault()}
-          className="swiper-button-prev-highlights absolute left-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-        >
-          <ChevronLeft size={16} />
-        </button>
-        <button
-          type="button"
-          aria-label="下一張花絮"
-          onMouseDown={(e) => e.preventDefault()}
-          className="swiper-button-next-highlights absolute right-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-        >
-          <ChevronRight size={16} />
-        </button>
+        <CarouselNavButton
+          direction="prev"
+          triggerClassName="swiper-button-prev-highlights"
+          positionClassName="left-4"
+          ariaLabel="上一張花絮"
+        />
+        <CarouselNavButton
+          direction="next"
+          triggerClassName="swiper-button-next-highlights"
+          positionClassName="right-4"
+          ariaLabel="下一張花絮"
+        />
       </div>
       {selectedImage && (
         <ClickFocus

--- a/app/HomeEventHighlights/HomeEventHighlights.tsx
+++ b/app/HomeEventHighlights/HomeEventHighlights.tsx
@@ -108,7 +108,7 @@ export default function HomeEventHighlights() {
           type="button"
           aria-label="上一張花絮"
           onMouseDown={(e) => e.preventDefault()}
-          className="swiper-button-prev-highlights absolute left-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+          className="swiper-button-prev-highlights absolute left-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
         >
           <ChevronLeft size={16} />
         </button>
@@ -116,7 +116,7 @@ export default function HomeEventHighlights() {
           type="button"
           aria-label="下一張花絮"
           onMouseDown={(e) => e.preventDefault()}
-          className="swiper-button-next-highlights absolute right-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+          className="swiper-button-next-highlights absolute right-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
         >
           <ChevronRight size={16} />
         </button>

--- a/app/HomeEventHighlights/HomeEventHighlights.tsx
+++ b/app/HomeEventHighlights/HomeEventHighlights.tsx
@@ -104,12 +104,22 @@ export default function HomeEventHighlights() {
           ))}
         </Swiper>
 
-        <div className="swiper-button-prev-highlights absolute left-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100">
+        <button
+          type="button"
+          aria-label="上一張花絮"
+          onMouseDown={(e) => e.preventDefault()}
+          className="swiper-button-prev-highlights absolute left-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+        >
           <ChevronLeft size={16} />
-        </div>
-        <div className="swiper-button-next-highlights absolute right-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100">
+        </button>
+        <button
+          type="button"
+          aria-label="下一張花絮"
+          onMouseDown={(e) => e.preventDefault()}
+          className="swiper-button-next-highlights absolute right-4 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+        >
           <ChevronRight size={16} />
-        </div>
+        </button>
       </div>
       {selectedImage && (
         <ClickFocus

--- a/app/HomeFAQCarousel/HomeFAQCarousel.tsx
+++ b/app/HomeFAQCarousel/HomeFAQCarousel.tsx
@@ -201,14 +201,14 @@ export default function HomeFAQCarousel() {
 
         <button
           type="button"
-          className="swiper-button-prev-faq absolute left-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100"
+          className="swiper-button-prev-faq absolute left-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
           aria-label="上一張 FAQ"
         >
           <ChevronLeft size={16} />
         </button>
         <button
           type="button"
-          className="swiper-button-next-faq absolute right-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100"
+          className="swiper-button-next-faq absolute right-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
           aria-label="下一張 FAQ"
         >
           <ChevronRight size={16} />

--- a/app/HomeFAQCarousel/HomeFAQCarousel.tsx
+++ b/app/HomeFAQCarousel/HomeFAQCarousel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination } from "swiper/modules";
 
 import Article from "../components/Article";
+import CarouselNavButton from "../components/CarouselNavButton";
 import H1 from "../components/H1";
 import H2 from "../components/H2";
 
@@ -199,20 +199,18 @@ export default function HomeFAQCarousel() {
           ))}
         </Swiper>
 
-        <button
-          type="button"
-          className="swiper-button-prev-faq absolute left-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-          aria-label="上一張 FAQ"
-        >
-          <ChevronLeft size={16} />
-        </button>
-        <button
-          type="button"
-          className="swiper-button-next-faq absolute right-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/60 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/80 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-          aria-label="下一張 FAQ"
-        >
-          <ChevronRight size={16} />
-        </button>
+        <CarouselNavButton
+          direction="prev"
+          triggerClassName="swiper-button-prev-faq"
+          positionClassName="left-2"
+          ariaLabel="上一張 FAQ"
+        />
+        <CarouselNavButton
+          direction="next"
+          triggerClassName="swiper-button-next-faq"
+          positionClassName="right-2"
+          ariaLabel="下一張 FAQ"
+        />
       </div>
     </Article>
   );

--- a/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
+++ b/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
@@ -1,10 +1,9 @@
 "use client";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination, Autoplay } from "swiper/modules";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-
 import H2 from "../components/H2";
 import Article from "../components/Article";
+import CarouselNavButton from "../components/CarouselNavButton";
 import WinnerSectionCard from "./component/winnerSectionCard";
 import {
   type winnerSectionProps,
@@ -47,22 +46,18 @@ export default function HomeWinnerCarousel() {
             ))}
           </Swiper>
 
-          <button
-            type="button"
-            aria-label="上一個優勝作品"
-            onMouseDown={(e) => e.preventDefault()}
-            className="swiper-button-prev-winners absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-          >
-            <ChevronLeft size={16} />
-          </button>
-          <button
-            type="button"
-            aria-label="下一個優勝作品"
-            onMouseDown={(e) => e.preventDefault()}
-            className="swiper-button-next-winners absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
-          >
-            <ChevronRight size={16} />
-          </button>
+          <CarouselNavButton
+            direction="prev"
+            triggerClassName="swiper-button-prev-winners"
+            positionClassName="left-1"
+            ariaLabel="上一個優勝作品"
+          />
+          <CarouselNavButton
+            direction="next"
+            triggerClassName="swiper-button-next-winners"
+            positionClassName="right-1"
+            ariaLabel="下一個優勝作品"
+          />
         </div>
       </Article>
     </div>

--- a/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
+++ b/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
@@ -51,7 +51,7 @@ export default function HomeWinnerCarousel() {
             type="button"
             aria-label="上一個優勝作品"
             onMouseDown={(e) => e.preventDefault()}
-            className="swiper-button-prev-winners absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+            className="swiper-button-prev-winners absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
           >
             <ChevronLeft size={16} />
           </button>
@@ -59,7 +59,7 @@ export default function HomeWinnerCarousel() {
             type="button"
             aria-label="下一個優勝作品"
             onMouseDown={(e) => e.preventDefault()}
-            className="swiper-button-next-winners absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+            className="swiper-button-next-winners absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40"
           >
             <ChevronRight size={16} />
           </button>

--- a/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
+++ b/app/HomeWinnerCarousel/HomeWinnerCarousel.tsx
@@ -24,10 +24,10 @@ export default function HomeWinnerCarousel() {
           <Swiper
             modules={[Navigation, Pagination, Autoplay]}
             slidesPerView={1}
-            centeredSlides={true}
             loop={true}
             autoplay={{
               delay: 8000,
+              disableOnInteraction: false,
             }}
             pagination={{
               clickable: true,
@@ -36,42 +36,33 @@ export default function HomeWinnerCarousel() {
               nextEl: ".swiper-button-next-winners",
               prevEl: ".swiper-button-prev-winners",
             }}
-            className="w-full"
-            onInit={(swiper) => {
-              setTimeout(() => {
-                const slides = swiper.slides;
-                let maxHeight = 0;
-
-                slides.forEach((slide) => {
-                  slide.style.height = "auto";
-                  const slideHeight = slide.offsetHeight;
-                  if (slideHeight > maxHeight) {
-                    maxHeight = slideHeight;
-                  }
-                });
-
-                slides.forEach((slide) => {
-                  slide.style.height = `${maxHeight}px`;
-                });
-              }, 100);
-            }}
+            className="w-full select-none pb-10 [&_.swiper-slide]:h-auto [&_.swiper-wrapper]:items-stretch"
           >
             {winnerSectionList.map((section: winnerSectionProps) => (
-              <SwiperSlide
-                key={section.id}
-                className="flex items-center justify-center bg-[#F2F1EF33] rounded-lg shadow-[1.5px_2px_3.5px_0px_rgba(0,0,0,0.1),2px_2px_4px_0px_rgba(255,255,255,0.3),inset_-2px_-2px_4px_0px_rgba(0,0,0,0.1)]"
-              >
-                <WinnerSectionCard {...section} />
+              <SwiperSlide key={section.id} className="!flex">
+                <div className="w-full flex items-center justify-center bg-[#F2F1EF33] rounded-lg shadow-[1.5px_2px_3.5px_0px_rgba(0,0,0,0.1),2px_2px_4px_0px_rgba(255,255,255,0.3),inset_-2px_-2px_4px_0px_rgba(0,0,0,0.1)]">
+                  <WinnerSectionCard {...section} />
+                </div>
               </SwiperSlide>
             ))}
           </Swiper>
 
-          <div className="swiper-button-prev-winners absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100">
+          <button
+            type="button"
+            aria-label="上一個優勝作品"
+            onMouseDown={(e) => e.preventDefault()}
+            className="swiper-button-prev-winners absolute left-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+          >
             <ChevronLeft size={16} />
-          </div>
-          <div className="swiper-button-next-winners absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100">
+          </button>
+          <button
+            type="button"
+            aria-label="下一個優勝作品"
+            onMouseDown={(e) => e.preventDefault()}
+            className="swiper-button-next-winners absolute right-1 top-1/2 -translate-y-1/2 z-10 cursor-pointer p-2 rounded-full leading-none bg-white bg-opacity-40 hover:bg-opacity-60 transition-all duration-300 opacity-0 group-hover:opacity-100"
+          >
             <ChevronRight size={16} />
-          </div>
+          </button>
         </div>
       </Article>
     </div>

--- a/app/HomeWinnerCarousel/component/winnerSectionCard.tsx
+++ b/app/HomeWinnerCarousel/component/winnerSectionCard.tsx
@@ -14,7 +14,14 @@ export default function WinnerSectionCard(winner: winnerSectionProps) {
 
       <div className="flex flex-col lg:flex-row lg:items-stretch lg:space-x-12">
         <div className="w-full lg:w-1/3 flex justify-center lg:justify-start mb-8 lg:mb-0">
-          <Image src={winner.img} alt={winner.alt} width={300} height={100} />
+          <Image
+            src={winner.img}
+            alt={winner.alt}
+            width={300}
+            height={100}
+            draggable={false}
+            className="pointer-events-none select-none"
+          />
         </div>
 
         <div className="w-full lg:w-2/3 flex flex-col justify-between">

--- a/app/components/CarouselNavButton.tsx
+++ b/app/components/CarouselNavButton.tsx
@@ -1,0 +1,33 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CarouselNavButtonProps {
+  direction: "prev" | "next";
+  triggerClassName: string;
+  positionClassName: string;
+  ariaLabel: string;
+}
+
+export default function CarouselNavButton({
+  direction,
+  triggerClassName,
+  positionClassName,
+  ariaLabel,
+}: CarouselNavButtonProps) {
+  const Icon = direction === "prev" ? ChevronLeft : ChevronRight;
+
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onMouseDown={(e) => e.preventDefault()}
+      className={cn(
+        triggerClassName,
+        positionClassName,
+        "absolute top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/40 p-2 leading-none opacity-0 transition-all duration-300 hover:bg-white/60 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40",
+      )}
+    >
+      <Icon size={16} />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Convert Event Highlights and Winner Works carousel navigation from `<div>` to semantic `<button>` with `aria-label` and `onMouseDown` preventDefault, eliminating unwanted text selection on click/drag.
- Replace `onInit` setTimeout-based slide height equalization in Winner Works with a pure CSS flexbox approach (`[&_.swiper-slide]:h-auto [&_.swiper-wrapper]:items-stretch`), fixing the blank slide bug during navigation.
- Prevent image drag/text selection on winner cards (`draggable={false}`, `pointer-events-none`, `select-none`) and let autoplay continue after user interaction (`disableOnInteraction: false`).

## Test plan
- [ ] Hover Event Highlights carousel → nav buttons appear; click/drag them and verify no text is selected
- [ ] Hover Winner Works carousel → nav buttons appear; click through every slide and confirm no blank slides
- [ ] Drag/swipe winner slide image → no ghost drag image, no text selection
- [ ] Wait through one autoplay cycle after interacting → autoplay resumes
- [ ] Keyboard: Tab to nav buttons, confirm focus and Enter advances slide