### PR TITLE
Fix card height issues in HomeFAQCarousel and update showcase

### DIFF
--- a/app/HomeFAQCarousel/HomeFAQCarousel.tsx
+++ b/app/HomeFAQCarousel/HomeFAQCarousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination } from "swiper/modules";
 
@@ -134,12 +135,40 @@ const faqItems = [
 ];
 
 export default function HomeFAQCarousel() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [maxHeight, setMaxHeight] = useState<number>(0);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const measure = () => {
+      const cards = container.querySelectorAll<HTMLElement>("[data-faq-card]");
+      if (cards.length === 0) return;
+      cards.forEach((card) => {
+        card.style.minHeight = "0px";
+      });
+      let tallest = 0;
+      cards.forEach((card) => {
+        tallest = Math.max(tallest, card.scrollHeight);
+      });
+      setMaxHeight(tallest);
+    };
+
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+
   return (
     <Article id="home-faq">
       <H1>常見問題</H1>
       <H2>報名前 FAQ</H2>
 
-      <div className="relative mx-auto mt-8 overflow-hidden group">
+      <div
+        ref={containerRef}
+        className="relative mx-auto mt-8 overflow-hidden group"
+      >
         <Swiper
           modules={[Navigation, Pagination]}
           spaceBetween={14}
@@ -177,7 +206,11 @@ export default function HomeFAQCarousel() {
                     isActive ? "scale-100" : "scale-95 opacity-70"
                   }`}
                 >
-                  <div className="relative flex h-[540px] flex-col overflow-hidden rounded-md bg-[#F3F1EC] p-6 text-[#4C4C4C] shadow-[1.5px_2px_3.5px_0px_rgba(0,0,0,0.1),2px_2px_4px_0px_rgba(255,255,255,0.3),inset_-2px_-2px_4px_0px_rgba(0,0,0,0.06)] sm:h-[520px] sm:p-7 md:h-[505px]">
+                  <div
+                    data-faq-card
+                    style={maxHeight > 0 ? { minHeight: maxHeight } : undefined}
+                    className="relative flex flex-col overflow-hidden rounded-md bg-[#F3F1EC] p-6 text-[#4C4C4C] shadow-[1.5px_2px_3.5px_0px_rgba(0,0,0,0.1),2px_2px_4px_0px_rgba(255,255,255,0.3),inset_-2px_-2px_4px_0px_rgba(0,0,0,0.06)] sm:p-7"
+                  >
                     <div className="absolute right-5 top-0 h-16 w-9 border-l-4 border-[#1E1E1E] bg-[#39A85A]" />
                     <div className="absolute -left-12 -top-16 h-32 w-32 rounded-full bg-[#F5B600]" />
 

--- a/app/HomeFAQCarousel/HomeFAQCarousel.tsx
+++ b/app/HomeFAQCarousel/HomeFAQCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation, Pagination } from "swiper/modules";
 
@@ -138,27 +138,29 @@ export default function HomeFAQCarousel() {
   const containerRef = useRef<HTMLDivElement>(null);
   const [maxHeight, setMaxHeight] = useState<number>(0);
 
-  useLayoutEffect(() => {
+  const measure = useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
+    const cards = container.querySelectorAll<HTMLElement>("[data-faq-card]");
+    if (cards.length === 0) return;
+    cards.forEach((card) => {
+      card.style.minHeight = "0px";
+    });
+    let tallest = 0;
+    cards.forEach((card) => {
+      tallest = Math.max(tallest, card.scrollHeight);
+    });
+    cards.forEach((card) => {
+      card.style.minHeight = `${tallest}px`;
+    });
+    setMaxHeight(tallest);
+  }, []);
 
-    const measure = () => {
-      const cards = container.querySelectorAll<HTMLElement>("[data-faq-card]");
-      if (cards.length === 0) return;
-      cards.forEach((card) => {
-        card.style.minHeight = "0px";
-      });
-      let tallest = 0;
-      cards.forEach((card) => {
-        tallest = Math.max(tallest, card.scrollHeight);
-      });
-      setMaxHeight(tallest);
-    };
-
+  useLayoutEffect(() => {
     measure();
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
-  }, []);
+  }, [measure]);
 
   return (
     <Article id="home-faq">
@@ -196,6 +198,8 @@ export default function HomeFAQCarousel() {
             nextEl: ".swiper-button-next-faq",
             prevEl: ".swiper-button-prev-faq",
           }}
+          onInit={measure}
+          onSlideChangeTransitionEnd={measure}
           className="w-full pb-10 [&_.swiper-slide]:h-auto [&_.swiper-wrapper]:items-stretch"
         >
           {faqItems.map((item) => (

--- a/app/HomeWinnerCarousel/component/winnerSectionProps.tsx
+++ b/app/HomeWinnerCarousel/component/winnerSectionProps.tsx
@@ -21,7 +21,7 @@ export const winnerSectionList: winnerSectionProps[] = [
     alt: "Winner 1",
     route: "Google Cloud 賽道",
     groupNumber: "二",
-    groupMember: "陳若瑛、黃乙家、陳昕宏、林雨臻",
+    groupMember: "許新翎、陳乃嘉、周恩宇、顏子綺",
     title: "Solarlytics: 陽光下的智慧決策",
     content:
       "Solarlytics: 陽光下的智慧決策是一個自助試算太陽能評估平台，專為解決民眾在安裝屋頂太陽能時遇到的資訊不透明、難以評估與決策門檻高等問題。平台結合 Google Cloud 技術，整合日照、地點、品牌、效率、成本等多元參數，讓使用者能夠快速評估自家安裝太陽能的適配性、投資回收期與效益，並提供多品牌比較與個人化方案建議，協助用戶做出最佳決策。",
@@ -48,6 +48,6 @@ export const winnerSectionList: winnerSectionProps[] = [
     groupMember: "陳若瑛、黃乙家、陳昕宏、林雨臻",
     title: "GreenBubble 綠泡泡",
     content:
-      "「陽光下的智慧決策」是臺灣首個自助試算太陽能評估平台，專為解決民眾在安裝屋頂太陽能時遇到的資訊不透明、難以評估與決策門檻高等問題。平台結合 Google Cloud 技術，整合日照、地點、品牌、效率、成本等多元參數，讓使用者能夠快速評估自家安裝太陽能的適配性、投資回收期與效益，並提供多品牌比較與個人化方案建議，協助用戶做出最佳決策。",
+      "你知道自己每天吸入多少 PM2.5 和微塑膠嗎？這款應用程式透過記錄交通、飲食、運動等日常行為，將污染暴露量轉化為視覺化圖表，讓永續不再只是口號，而是成為每個人可感知、可實踐的生活指南。團隊運用 Flutter、Supabase、Firebase 與 Google Maps API 打造完整 App，實現個人化環境數據追蹤。",
   },
 ];


### PR DESCRIPTION
This pull request introduces improvements to the FAQ carousel's responsiveness and updates to the winner section data. The most significant changes are an enhancement to the `HomeFAQCarousel` component to ensure all FAQ cards have equal height for a better user experience, and corrections to the winner information and project descriptions.

**UI/UX Improvements to FAQ Carousel:**

* Added logic in `HomeFAQCarousel.tsx` to dynamically measure and set the minimum height of all FAQ cards, ensuring consistent card heights regardless of content. This uses `useRef`, `useState`, `useCallback`, and `useLayoutEffect` to recalculate on mount, window resize, and slide change. [[1]](diffhunk://#diff-559fdc513a8fde99c95a3746957871f265eb9858b721ec1c78265c246675eb26R3) [[2]](diffhunk://#diff-559fdc513a8fde99c95a3746957871f265eb9858b721ec1c78265c246675eb26R138-R173) [[3]](diffhunk://#diff-559fdc513a8fde99c95a3746957871f265eb9858b721ec1c78265c246675eb26R201-R202) [[4]](diffhunk://#diff-559fdc513a8fde99c95a3746957871f265eb9858b721ec1c78265c246675eb26L180-R217)

**Content and Data Updates:**

* Updated the `winnerSectionList` in `winnerSectionProps.tsx` to correct the group members for the "Google Cloud 賽道" project.
* Replaced the project description for "GreenBubble 綠泡泡" with a new, accurate summary of the app's features and technology stack.