### PR TITLE
feat(Footer): add year archive section linking to /2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 /.next/
 /out/
 
+# archive build (generated at deploy time)
+/.archive-2025/
+/public/2025/
+
 # production
 /build
 

--- a/app/Footer/Footer.tsx
+++ b/app/Footer/Footer.tsx
@@ -45,6 +45,8 @@ export const Footer: React.FC = () => {
     },
   ];
 
+  const years = [{ label: "2025", url: "/2025" }];
+
   return (
     <footer
       className="w-full p-6 flex flex-col items-center bg-cover bg-center bg-no-repeat shadow-[inset_0px_4px_24px_0px_rgba(0,0,0,0.25)]"
@@ -81,6 +83,21 @@ export const Footer: React.FC = () => {
               ))}
             </div>
           ))}
+        </div>
+        <div className="self-stretch not-md:border-b-2 md:border-r-2 border-black"></div>
+        <div className="flex flex-col items-center md:items-start gap-4 md:self-start md:p-4">
+          <div className="font-bold text-xs tracking-[0.2em]">歷年網站</div>
+          <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+            {years.map((year) => (
+              <a
+                key={year.label}
+                href={year.url}
+                className="text-[11px] tracking-widest"
+              >
+                {year.label}
+              </a>
+            ))}
+          </div>
         </div>
       </div>
       <p className="text-[11px] tracking-wide">© 2026 DevJam TW 2026</p>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [{ source: "/2025", destination: "/2025/index.html" }];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build:archive": "./scripts/build-archive.sh",
+    "build": "pnpm build:archive && next build",
     "start": "next start",
     "format": "prettier --write .",
     "lint": "next lint",

--- a/scripts/build-archive.sh
+++ b/scripts/build-archive.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the 2025 archive site from the `2025` branch and stage it under
+# public/2025/ so the main deployment serves it as static files. Output
+# is generated at deploy time and never committed to git.
+set -euo pipefail
+
+ARCHIVE_BRANCH="2025"
+WORKTREE=".archive-2025"
+TARGET="public/2025"
+
+# Tidy up any leftover from a failed previous run.
+git worktree remove --force "$WORKTREE" 2>/dev/null || true
+rm -rf "$WORKTREE"
+
+git fetch origin "$ARCHIVE_BRANCH" --depth 1
+git worktree add --detach "$WORKTREE" "origin/$ARCHIVE_BRANCH"
+
+pnpm -C "$WORKTREE" install --frozen-lockfile
+pnpm -C "$WORKTREE" build
+
+rm -rf "$TARGET"
+mkdir -p "$TARGET"
+cp -R "$WORKTREE/out/2025/." "$TARGET/"
+
+git worktree remove --force "$WORKTREE"


### PR DESCRIPTION
- Add a "歷年網站" column in the footer with a 2025 entry
- Serve the 2025 archive as a static export under public/2025/
- Rewrite /2025 to /2025/index.html so the bare URL resolves
<img width="1468" height="219" alt="Screenshot 2026-05-28 at 3 37 33 AM" src="https://github.com/user-attachments/assets/d38abb0a-b364-4568-99e7-072e7158b04c" />
