### PR TITLE
fix(HomeSponsor): update the number of GDG on Campus schools to 25

### DIFF
--- a/app/HomeIntroduction/HomeIntroduction.tsx
+++ b/app/HomeIntroduction/HomeIntroduction.tsx
@@ -30,7 +30,7 @@ export default function HomeIntroduction() {
         />
       </H2>
       <P>
-        DevJam TW 2026 是由全臺 26 所大學的 Google Developer Groups on Campus
+        DevJam TW 2026 是由全臺 25 所大學的 Google Developer Groups on Campus
         合作舉辦，專為學生開發者打造的黑客松舞台。
       </P>
       <P>

--- a/app/HomeSponsor/HomeSponsor.tsx
+++ b/app/HomeSponsor/HomeSponsor.tsx
@@ -22,7 +22,7 @@ export default function HomeSponsor() {
       <H2>協辦單位</H2>
       <SponsorContainer>
         <p className="text-sm/relaxed tracking-wide">
-          全臺 GDG on Campus（共 26 間學校）
+          全臺 GDG on Campus（共 25 間學校）
         </p>
       </SponsorContainer>
 


### PR DESCRIPTION
This pull request makes a minor update to the sponsor information on the homepage, correcting the number of participating GDG on Campus schools from 26 to 25.

- Updated the text in `HomeSponsor.tsx` to reflect the correct number of GDG on Campus schools as 25 instead of 26.